### PR TITLE
stylix/droid: fix import droid modules

### DIFF
--- a/stylix/droid/default.nix
+++ b/stylix/droid/default.nix
@@ -4,10 +4,10 @@ let
 in
 {
   imports = [
-    ../fonts.nix
+    ./fonts.nix
+    ./palette.nix
     ../home-manager-integration.nix
     ../opacity.nix
-    ../palette.nix
     ../pixel.nix
     ../target.nix
     ../overlays.nix


### PR DESCRIPTION
<!-- Describe your PR above, following Stylix commit conventions. -->
Fixed the lack of import of specific settings files for the `nix-on-droid` module.
This made it possible to export color palette files and set fonts for this system.

---

### Submission Checklist
<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->

- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch

<!---
### Notify Maintainers

Consider pinging relevant module maintainers declared in
`modules/<MODULE>/meta.nix`.
-->
